### PR TITLE
Disallow access to /dev and /run

### DIFF
--- a/snekbox/nsjail.py
+++ b/snekbox/nsjail.py
@@ -127,6 +127,8 @@ class NsJail:
                 "-E", "VECLIB_MAXIMUM_THREADS=1",
                 "-E", "NUMEXPR_NUM_THREADS=1",
                 "-R/usr", "-R/lib", "-R/lib64",
+                "-m", "none:/dev:tmpfs:size=0",
+                "-m", "none:/run:tmpfs:size=0",
                 "--user", "65534",  # nobody
                 "--group", "65534",  # nobody/nogroup
                 "--time_limit", "2",

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -122,3 +122,33 @@ class NsJailTests(unittest.TestCase):
             "INFO:snekbox.nsjail:pid=20 ([STANDALONE MODE]) exited with status: 2, (PIDs left: 0)",
             log.output
         )
+
+    def test_dev_shm(self):
+        code = dedent("""
+        with open('/dev/shm/test', 'wb') as file:
+            file.write(bytes([255]))
+        """).strip()
+
+        result = self.nsjail.python3(code)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stderr, None)
+
+    def test_run_shm(self):
+        code = dedent("""
+        with open('/run/shm/test', 'wb') as file:
+            file.write(bytes([255]))
+        """).strip()
+
+        result = self.nsjail.python3(code)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stderr, None)
+
+    def test_tmp(self):
+        code = dedent("""
+        with open('/tmp/test', 'wb') as file:
+            file.write(bytes([255]))
+        """).strip()
+
+        result = self.nsjail.python3(code)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stderr, None)

--- a/tests/test_nsjail.py
+++ b/tests/test_nsjail.py
@@ -152,3 +152,16 @@ class NsJailTests(unittest.TestCase):
         result = self.nsjail.python3(code)
         self.assertEqual(result.returncode, 1)
         self.assertEqual(result.stderr, None)
+
+    def test_multiprocessing_shm(self):
+        code = dedent("""
+        from multiprocessing.shared_memory import SharedMemory
+        try:
+            SharedMemory('test', create=True, size=16)
+        except FileExistsError:
+            pass
+        """).strip()
+
+        result = self.nsjail.python3(code)
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stderr, None)


### PR DESCRIPTION
Previously, it was possible to deplete snekbox's memory by filling `/dev/shm`
as it doesn't seem to be affected by the read only mount of the filesystem.
This resulted in all subsequent usage failing due to lack of memory.
Presumably, this flaw would extend to `/run/shm` also if available.

To prevent such an issue, these changes block access to `/dev` and `/run` . This is done by mounting dummies in place of these directories.

As a result, `multiprocessing.shared_memory` will no longer function since it relies on `/dev/shm`.